### PR TITLE
Microchange for small detect fail in autogen.sh

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -17,12 +17,18 @@ echo autoheader...
 autoheader
 
 echo libtoolize...
-(libtoolize --version) < /dev/null > /dev/null 2>&1 || {
-    echo libtoolize not found
-    exit 1
-}
+if which libtoolize > /dev/null; then
+  echo "Found libtoolize"
+  LIBTOOLIZE='libtoolize'
+elif which glibtoolize > /dev/null; then
+  echo "Found glibtoolize"
+  LIBTOOLIZE='glibtoolize'
+else
+  echo "Failed to find libtoolize or glibtoolize, please ensure it is installed and accessible via your PATH env variable"
+  exit 1
+fi;
 
-libtoolize --automake --copy --force
+$LIBTOOLIZE  --automake --copy --force
 
 echo automake...
 (automake --version) < /dev/null > /dev/null 2>&1 || {


### PR DESCRIPTION
The ./autogen.sh was not checking for glibtoolize when failed to detect libtoolize.

*\* Forget about this one, I will follow bregma suggestions and ask for new pull after testing this.
-- Chat reference -- 
[01:16am] bregma_: I would recommend just replacing the contents of autogen.sh with just autoreconf -if, it just does the right thing (most autogen.sh scripts predate autoreconf)
[01:17am] bregma_: you might file a pull request for that, after doing your testing
[01:17am] dvicino: okis, I will
[01:18am] bregma_: it also means you should remove config.sub, config.guess, ltmain.sh, and libtool from source control because autoreconf will generate up-to-date ones that will not break builds when checkout out on incompatible platforms
[01:18am] bregma_: it's not required, though
