### PR TITLE
Adds the protocol spec files to the source distribution.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4,7 +4,7 @@ SUBDIRS = Atlas tests tools tutorial benchmark
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = atlascpp-0.6.pc
 
-EXTRA_DIST = HACKING ROADMAP Doxyfile footer.html index.dox
+EXTRA_DIST = HACKING ROADMAP Doxyfile footer.html index.dox protocol
 
 docs:
 	@echo "running doxygen..."


### PR DESCRIPTION
The test suite fails on some architectures without the spec file,
and some distributions require all source to be made available for
rebuilds.  Note that the test suite should fail on all architectures
but it doesn't because the failure in this case is invoking undefined
behaviour.

See http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=664549
