### PR TITLE
Add man page for atlas_convert

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,6 @@
 ACLOCAL_AMFLAGS = -I m4
 
-SUBDIRS = Atlas tests tools tutorial benchmark
+SUBDIRS = Atlas tests tools tutorial benchmark man
 
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = atlascpp-0.7.pc

--- a/configure.ac
+++ b/configure.ac
@@ -138,6 +138,8 @@ AC_CONFIG_FILES([
 	tests/Objects/Makefile
 	tests/Codecs/Makefile
 	tools/Makefile
+	man/Makefile
+	man/man1/Makefile
 	benchmark/Makefile
 	tutorial/Makefile
 	atlas-cpp.spec

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -1,0 +1,1 @@
+SUBDIRS = man1

--- a/man/man1/Makefile.am
+++ b/man/man1/Makefile.am
@@ -1,0 +1,5 @@
+man_MANS = \
+        atlas_convert.1
+
+EXTRA_DIST= ${man_MANS}
+

--- a/man/man1/atlas_convert.1
+++ b/man/man1/atlas_convert.1
@@ -1,0 +1,42 @@
+.TH atlas_convert 1 "January 11, 2012" "" "atlas_convert"
+
+.SH NAME
+atlas_convert \- convert Atlas data files
+
+.SH SYNOPSIS
+.B atlas_convert [
+.B -f ]
+.B [ \-s
+.I spacing
+.B ]
+.B [ \-i
+.I input_codec
+.B ]
+.B [ \-o
+.I output_codec
+.B ]
+
+.SH DESCRIPTION
+This tool converts Atlas data files between formats using
+.IR codecs .
+
+Supported codecs include
+.IR XML ,
+.IR Bach ,
+and
+.IR Packed .
+
+.SH OPTIONS
+.IP \-f
+Enables formatted output.
+
+.IP \-s
+Sets the spacing.
+
+.IP \-i
+Selects the input
+.I codec.
+
+.IP \-o
+Selects the output
+.I codec.


### PR DESCRIPTION
Man page was written by Stephen M. Webb for Debian packaging in 2012. Not sure why this was never rolled back up into the source tree here.